### PR TITLE
fix: updates css to target heroImage in production env

### DIFF
--- a/src/components/SVGImage/styles.module.css
+++ b/src/components/SVGImage/styles.module.css
@@ -1,21 +1,16 @@
 
-.mainSvg {
+.heroImage {
     height: 400px;
     width: 400px;
     min-width: 400px;
   }
-
-
-
 .chefHatSvg {
   width: 24px;
 
 }
 
-
-
 @media screen and (max-width: 996px) {
-    .mainSvg {
+    .heroImage {
         display: none;
     }
   }

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -361,9 +361,6 @@
 }
 
 @media screen and (max-width: 700px) {
-  [class^='heroImage_src-pages-index-module'] {
-    display: none;
-  }
   [class^='heroTitle_src-pages-index-module'] {
     font-size: 56px !important;
     line-height: 72px !important;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -19,7 +19,7 @@ function HomepageHeader() {
   return (
     <header className={styles.heroBanner}>
       <div className={styles.heroImage}>
-        <SVGImage Svg={heroImage.default} />
+        <SVGImage Svg={heroImage.default} classNameOverride="heroImage" />
       </div>
       <div className={styles.headerRight}>
         <div className="titleContainer">


### PR DESCRIPTION
The production build of the site adds some random characters to the end of the classname which messed up the style targeting. I'm going to do another PR to clean up and try to not use the `[class^='ABC']` syntax except when necessary.


https://user-images.githubusercontent.com/8878532/211581567-6369a7ae-9607-46eb-abd3-4f135401046c.mov

