### PR TITLE
fix: changed how we grabbed link

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -47,7 +47,7 @@ const NewSection = () => {
         </p>
         <Link
           className={styles.notificationLink}
-          to={`/docs/recipes/${mostRecentRecipe.doc_name.split(".")[0]}}`}
+          to={`/docs/recipes/${mostRecentRecipe.doc_name.split(".")[0]}`}
         >
           <b className={styles.notificationLinkText}>View recipe</b>
           <Arrow.default />

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -47,7 +47,7 @@ const NewSection = () => {
         </p>
         <Link
           className={styles.notificationLink}
-          to={`/docs/recipes/${mostRecentRecipe.doc_name.slice(0, -3)}`}
+          to={`/docs/recipes/${mostRecentRecipe.doc_name.split(".")[0]}}`}
         >
           <b className={styles.notificationLinkText}>View recipe</b>
           <Arrow.default />


### PR DESCRIPTION
The previous way we grabbed the docname for the link assumed it was a `.md` file. Now we just grab everything before the `.`