### PR TITLE
fix(typescript-base-url): some better snippet copying

### DIFF
--- a/docs/recipes/TypeScriptBaseURL.md
+++ b/docs/recipes/TypeScriptBaseURL.md
@@ -27,7 +27,9 @@ import { Thing } from "~/components/thing";
 
 ## Project Dependencies
 
-`yarn add -D babel-plugin-root-import`
+```bash
+yarn add -D babel-plugin-root-import
+```
 
 ## TypeScript Configuration Changes
 
@@ -80,9 +82,15 @@ import { colors, spacing } from "~/theme";
 
 Fire up the app and make sure everything still works!
 
-`yarn expo:start`
+```bash
+yarn expo:start
+```
 
-_Note: if you receive an error about not being able to resolve the components, you may have to clear your bundler cache, `yarn expo:start --clear`_
+_Note: if you receive an error about not being able to resolve the components, you may have to clear your bundler cache via_
+
+```bash
+yarn expo:start --clear
+```
 
 ## Resources
 


### PR DESCRIPTION
- Fixes some small bash scripts that lacked syntax typing so we get the copy button

Before
![image](https://user-images.githubusercontent.com/374022/222211608-e6c8d988-0312-4082-b29f-ef7569c5eaab.png)


After
![image](https://user-images.githubusercontent.com/374022/222211855-7bf7bf82-06e4-47f4-9f4a-0d448dc6cab3.png)

- Updates the `tsconfig.json` edits to be more specific about the `compilerOptions` key