### PR TITLE
feat(recipes): new Zustand recipe, and separate recipe for removing MobX-State-Tree

### DIFF
--- a/docs/recipes/Redux.md
+++ b/docs/recipes/Redux.md
@@ -1,6 +1,6 @@
 ---
 title: Redux
-description: How to migrate a Mobx-State-Tree project to Redux
+description: How to migrate a MobX-State-Tree project to Redux
 tags:
   - Redux
   - MobX
@@ -12,7 +12,7 @@ publish_date: 2024-01-16
 
 # Redux
 
-This guide will show you how to migrate a Mobx-State-Tree project (Ignite's default) to Redux, using a newly created Ignite project as our example:
+This guide will show you how to migrate a MobX-State-Tree project (Ignite's default) to Redux, using a newly created Ignite project as our example:
 
 ```terminal
 npx ignite-cli new ReduxApp --yes --removeDemo
@@ -20,9 +20,9 @@ npx ignite-cli new ReduxApp --yes --removeDemo
 
 If you are migrating an existing project these steps still apply, but you may need to migrate your existing state tree and other additional functionality.
 
-## Remove Mobx-State-Tree
+## Remove MobX-State-Tree
 
-First, follow our recipe to [Remove Mobx-State-Tree](./RemoveMobxStateTree.md) from your project. This will give you a blank slate to setup Redux.
+First, follow our recipe to [Remove MobX-State-Tree](./RemoveMobxStateTree.md) from your project. This will give you a blank slate to setup Redux.
 
 ## Add Redux
 
@@ -69,8 +69,8 @@ export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector;
 #### Add State
 
 - Add your state reducers or [slices](https://redux-toolkit.js.org/usage/usage-guide#creating-slices-of-state). We'll create a simple `counter` slice for this example.
-- If you have an existing state tree with Mobx-State-Tree, you'll need to convert your tree into a series of Redux reducers.
-  - Note: Redux does not define or validate your models like Mobx-State-Tree does. It is up to you to ensure the correct data is being set in your reducers.
+- If you have an existing state tree with MobX-State-Tree, you'll need to convert your tree into a series of Redux reducers.
+  - Note: Redux does not define or validate your models like MobX-State-Tree does. It is up to you to ensure the correct data is being set in your reducers.
 
 **`app/store/counterSlice.ts`**
 
@@ -169,7 +169,7 @@ You're now using Redux!
 
 ## Persistence
 
-Ignite ships with built-in persistence support for Mobx-State-Tree. We can add similar support for Redux by:
+Ignite ships with built-in persistence support for MobX-State-Tree. We can add similar support for Redux by:
 
 1. Install [`redux-persist`](https://github.com/rt2zz/redux-persist)
 

--- a/docs/recipes/Redux.md
+++ b/docs/recipes/Redux.md
@@ -22,84 +22,7 @@ If you are migrating an existing project these steps still apply, but you may ne
 
 ## Remove Mobx-State-Tree
 
-- Remove all Mobx-related dependencies from `package.json`, then run `yarn` or `npm i`
-
-```diff
---"mobx": "6.10.2",
---"mobx-react-lite": "4.0.5",
---"mobx-state-tree": "5.3.0",
-
---"reactotron-mst": "3.1.5",
-```
-
-- Ignite created default boilerplate Mobx-State-Tree files in the `models/` directory. Remove this entire directory and all files within it, these are not needed for Redux.
-
-- In `devtools/ReactotronConfig.ts` remove the `reactotron-mst` plugin. We can come back to [add a Redux plugin](#reactotron-support) later.
-
-```diff
---import { mst } from "reactotron-mst"
-
-...
-
-const reactotron = Reactotron.configure({
-  name: require("../../package.json").name,
-  onConnect: () => {
-    /** since this file gets hot reloaded, let's clear the past logs every time we connect */
-    Reactotron.clear()
-  },
---}).use(
---  mst({
---    /** ignore some chatty `mobx-state-tree` actions  */
---    filter: (event) => /postProcessSnapshot|@APPLY_SNAPSHOT/.test(event.name) === false,
---  }),
---)
-++})
-```
-
-- Remove all `observer()` components and reformat as normal React components. Do a project-wide search for `observer(` and replace each component instance with the following pattern:
-
-```diff
---import { observer } from "mobx-react-lite"
-
---export const WelcomeScreen: FC<WelcomeScreenProps> = observer(function WelcomeScreen(props) {
-++export const WelcomeScreen: FC<WelcomeScreenProps> = (props) => {
-    ...
---})
-++}
-```
-
-- (optional) Don't forget to update your [Ignite Generator Templates](https://docs.infinite.red/ignite-cli/concept/Generator-Templates/)!
-  - Follow the same pattern to replace `observer()`. This will allow you to quickly generate screens and components via `npx ignite-cli generate screen NewScreen` and `npx ignite-cli generate component NewComponent` and use your updated syntax. (You can customize these however you like!)
-  - Update `ignite/templates/component/NAME.tsx.ejs` and `ignite/templates/screen/NAMEScreen.tsx.ejs`
-
-```diff
---import { observer } from "mobx-react-lite"
-
---export const <%= props.pascalCaseName %> = observer(function <%= props.pascalCaseName %>(props: <%= props.pascalCaseName %>Props) {
-++export const <%= props.pascalCaseName %> = (props: <%= props.pascalCaseName %>Props) => {
-    ...
---})
-++}
-```
-
-- Remove old Mobx-State-Tree store initialization / hydration code in `app.tsx`.
-- Call `hideSplashScreen` in a `useEffect` so the app loads for now. We'll replace this code when we add [persistence](#persistence) below.
-
-```diff
---import { useInitialRootStore } from "./models"
-
---const { rehydrated } = useInitialRootStore(() => {
---setTimeout(hideSplashScreen, 500)
---})
-++useEffect(() => {
-++    setTimeout(hideSplashScreen, 500)
-++}, [])
-
---if (!rehydrated || !isNavigationStateRestored || !areFontsLoaded) return null
-++if (!isNavigationStateRestored || !areFontsLoaded) return null
-```
-
-You should be able to build and run your app! It won't have any data...but it's a good idea to check that it successfully runs before we move on.
+First, follow our recipe to [Remove Mobx-State-Tree](./RemoveMobxStateTree.md) from your project. This will give you a blank slate to setup Redux.
 
 ## Add Redux
 
@@ -114,11 +37,12 @@ yarn add react-redux
 
 #### Create Store
 
-- In a new file `app/store.ts`, create your Redux store.
+- In a new file `app/store/store.ts`, create your Redux store.
   - Create an initial store. We're using [Redux Toolkit's `configureStore`](https://redux-toolkit.js.org/usage/usage-guide#simplifying-store-setup-with-configurestore) here for simplicity.
-  - Export Typescript helpers for the rest of your app to stay type safe
+  - Export Typescript helpers for the rest of your app to stay type safe.
+  - We'll use `app/store` directory for all our Redux reducers and store, but feel free to use any directory structure you like. Another popular option is to use [feature folders](https://redux.js.org/faq/code-structure).
 
-`store.ts`
+**`app/store/store.ts`**
 
 ```typescript
 import { configureStore } from "@reduxjs/toolkit";
@@ -148,7 +72,7 @@ export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector;
 - If you have an existing state tree with Mobx-State-Tree, you'll need to convert your tree into a series of Redux reducers.
   - Note: Redux does not define or validate your models like Mobx-State-Tree does. It is up to you to ensure the correct data is being set in your reducers.
 
-`counterSlice.ts`
+**`app/store/counterSlice.ts`**
 
 ```typescript
 import { createSlice } from "@reduxjs/toolkit";
@@ -185,6 +109,8 @@ export default counterSlice.reducer;
 
 In `app.tsx`, wrap your `AppNavigator` with the react-redux Provider component
 
+**`app/app.tsx`**
+
 ```jsx
 import { Provider } from "react-redux";
 import { store } from "./store/store";
@@ -206,7 +132,7 @@ You can now use selectors to grab data and `dispatch()` to execute actions withi
 
 - Remember to use our exported `useAppSelector` and `useAppDispatch` helpers for type safety
 
-`WelcomeScreen.tsx`
+**`app/screens/WelcomeScreen.tsx`**
 
 ```typescript
 import React, { FC } from "react";
@@ -253,22 +179,13 @@ yarn add redux-persist
 
 2. Modify `store.ts` to include `redux-persist`
 
-`store.ts`
+**`app/store/store.ts`**
 
 ```typescript
 import { combineReducers, configureStore } from "@reduxjs/toolkit";
 import counterReducer from "./counterSlice";
 import { TypedUseSelectorHook, useDispatch, useSelector } from "react-redux";
-import {
-  persistStore,
-  persistReducer,
-  FLUSH,
-  REHYDRATE,
-  PAUSE,
-  PERSIST,
-  PURGE,
-  REGISTER,
-} from "redux-persist";
+import { persistStore, persistReducer, FLUSH, REHYDRATE, PAUSE, PERSIST, PURGE, REGISTER } from "redux-persist";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 
 const persistConfig = {
@@ -307,7 +224,7 @@ export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector;
 
 3. Add a `PersistGate` to `app.tsx` and replace any existing `hideSplashScreen` calls with the `onBeforeLift` callback
 
-`app.tsx`
+**`app/app.tsx`**
 
 ```typescript
 ...

--- a/docs/recipes/RemoveMobxStateTree.md
+++ b/docs/recipes/RemoveMobxStateTree.md
@@ -1,6 +1,6 @@
 ---
-title: Remove Mobx-State-Tree
-description: How to remove Mobx-State-Tree from an Ignite project
+title: Remove MobX-State-Tree
+description: How to remove MobX-State-Tree from an Ignite project
 tags:
   - MobX
   - State Management
@@ -11,25 +11,19 @@ publish_date: 2024-02-05
 
 # Remove Mobx-State-Tree
 
-By default, Ignite uses [MobX-State-Tree](https://mobx-state-tree.js.org/) as the default state management solution. While we love [Mobx-State-Tree at Infinite Red](https://docs.infinite.red/ignite-cli/concept/MobX-State-Tree/), we understand the landscape is rich with great alternatives that you may want to use instead.
+By default, Ignite uses [MobX-State-Tree](https://mobx-state-tree.js.org/) as the default state management solution. While we love [MobX-State-Tree at Infinite Red](https://docs.infinite.red/ignite-cli/concept/MobX-State-Tree/), we understand the landscape is rich with great alternatives that you may want to use instead.
 
 This guide will show you how to remove Mobx-State-Tree from an Ignite-generated project and get to a "blank slate" with no state management at all.
 
 ## Steps
 
-1. Let's start by removing all Mobx-related dependencies from `package.json`, then run `yarn` or `npm i`
+1. Let's start by removing all MobX-related dependencies
 
-**package.json**
-
-```diff
---"mobx": "6.10.2",
---"mobx-react-lite": "4.0.5",
---"mobx-state-tree": "5.3.0",
-
---"reactotron-mst": "3.1.5",
+```bash
+yarn remove mobx mobx-react-lite mobx-state-tree reactotron-mst
 ```
 
-2. Ignite places all Mobx-State-Tree models in the `models/`. Remove this entire directory and all files within it, these are not needed anymore.
+2. Ignite places all MobX-State-Tree models in the `models/`. Remove this entire directory and all files within it, these are not needed anymore.
 
 ```terminal
 rm -rf ./app/models
@@ -66,6 +60,8 @@ const reactotron = Reactotron.configure({
 4. Remove `observer()` wrapped components and reformat as functional React components
 
 - Do a project-wide search for `observer(` and replace each component instance with the following pattern:
+
+**app/screens/WelcomeScreen.tsx**
 
 ```diff
 --import { observer } from "mobx-react-lite"
@@ -120,12 +116,36 @@ const AppStack = () => {
 --const { rehydrated } = useInitialRootStore(() => {
 --setTimeout(hideSplashScreen, 500)
 --})
-++useEffect(() => {
+++React.useEffect(() => {
 ++    setTimeout(hideSplashScreen, 500)
 ++}, [])
 
 --if (!rehydrated || !isNavigationStateRestored || !areFontsLoaded) return null
 ++if (!isNavigationStateRestored || !areFontsLoaded) return null
+```
+
+8. Remove any remaining `/models` imports
+
+Your app might have a few remaining references to replace. In the Ignite Demo App, we need to replace the `EpisodeSnapshotIn` type which was previously derived from the MST model. Instead, we'll use `EpisodeItem` from our API types.
+
+**app/services/api/api.ts**
+
+```diff
+--import type { ApiConfig, ApiFeedResponse } from "./api.types"
+--import type { EpisodeSnapshotIn } from "../../models/Episode"
+++import type { ApiConfig, ApiFeedResponse, EpisodeItem } from "./api.types"
+
+
+--async getEpisodes(): Promise<{ kind: "ok"; episodes: EpisodeSnapshotIn[] } | GeneralApiProblem> {
+++async getEpisodes(): Promise<{ kind: "ok"; episodes: EpisodeItem[] } | GeneralApiProblem> {
+// make the api call
+
+--// This is where we transform the data into the shape we expect for our MST model.
+--const episodes: EpisodeSnapshotIn[] =
+--  rawData?.items.map((raw) => ({
+--    ...raw,
+--  })) ?? []
+++const episodes = rawData?.items ?? []
 ```
 
 ## Conclusion

--- a/docs/recipes/RemoveMobxStateTree.md
+++ b/docs/recipes/RemoveMobxStateTree.md
@@ -77,7 +77,20 @@ const reactotron = Reactotron.configure({
 ++}
 ```
 
-5. Update the [Ignite Generator Templates](https://docs.infinite.red/ignite-cli/concept/Generator-Templates/)!
+5. Remove `useStores()` from components
+
+- Do a project-wide search for `useStores` and remove each instance.
+- If you're converting to a different state management solution, you'll need to swap the data we get from `useStores` to your new solution. Or you can swap in temporary hardcoded values to prevent crashes while you migrate. (just don't forget about it!)
+
+```diff
+--import { useStores } from "../models"
+
+const AppStack = () => {
+--  const { authenticationStore: { isAuthenticated } } = useStores()
+++  const isAuthenticated = false // TODO: TEMPORARY VALUE - replace with alternative state management solution
+```
+
+6. Update the [Ignite Generator Templates](https://docs.infinite.red/ignite-cli/concept/Generator-Templates/)!
 
 - Follow the same pattern to replace `observer()`. This will allow you to quickly generate screens and components via `npx ignite-cli generate screen NewScreen` and `npx ignite-cli generate component NewComponent` and use your updated syntax.
 - I also recommend customizing these however else you prefer!
@@ -95,7 +108,7 @@ const reactotron = Reactotron.configure({
 ++}
 ```
 
-6. Remove old Mobx-State-Tree store initialization & hydration code in `app.tsx`.
+7. Remove old Mobx-State-Tree store initialization & hydration code in `app.tsx`.
 
 - We still need to call `hideSplashScreen` in a `useEffect` so the app loads without needing to hydrate a store first.
 

--- a/docs/recipes/RemoveMobxStateTree.md
+++ b/docs/recipes/RemoveMobxStateTree.md
@@ -6,7 +6,7 @@ tags:
   - State Management
 last_update:
   author: Justin Poliachik
-publish_date: 2024-02-01
+publish_date: 2024-02-05
 ---
 
 # Remove Mobx-State-Tree

--- a/docs/recipes/RemoveMobxStateTree.md
+++ b/docs/recipes/RemoveMobxStateTree.md
@@ -1,0 +1,126 @@
+---
+title: Remove Mobx-State-Tree
+description: How to remove Mobx-State-Tree from an Ignite project
+tags:
+  - MobX
+  - State Management
+last_update:
+  author: Justin Poliachik
+publish_date: 2024-02-01
+---
+
+# Remove Mobx-State-Tree
+
+By default, Ignite uses [Mobx-State-Tree](https://mobx-state-tree.js.org/) as the default state management solution. While we love [Mobx-State-Tree at Infinite Red](https://docs.infinite.red/ignite-cli/concept/MobX-State-Tree/), we understand the landscape is rich with great alternatives that you may want to use instead.
+
+This guide will show you how to remove Mobx-State-Tree from an Ignite-generated project and get to a "blank slate" with no state management at all.
+
+## Steps
+
+1. Let's start by removing all Mobx-related dependencies from `package.json`, then run `yarn` or `npm i`
+
+**package.json**
+
+```diff
+--"mobx": "6.10.2",
+--"mobx-react-lite": "4.0.5",
+--"mobx-state-tree": "5.3.0",
+
+--"reactotron-mst": "3.1.5",
+```
+
+2. Ignite places all Mobx-State-Tree models in the `models/`. Remove this entire directory and all files within it, these are not needed anymore.
+
+```terminal
+rm -rf ./app/models
+```
+
+:::note
+If you are migrating a project with several existing models, you may want to keep a copy of these around for reference as you migrate to your new system.
+:::
+
+3. Remove the `reactotron-mst` plugin from Reactotron's config
+
+**devtools/ReactotronConfig.ts**
+
+```diff
+--import { mst } from "reactotron-mst"
+
+...
+
+const reactotron = Reactotron.configure({
+  name: require("../../package.json").name,
+  onConnect: () => {
+    /** since this file gets hot reloaded, let's clear the past logs every time we connect */
+    Reactotron.clear()
+  },
+--}).use(
+--  mst({
+--    /** ignore some chatty `mobx-state-tree` actions  */
+--    filter: (event) => /postProcessSnapshot|@APPLY_SNAPSHOT/.test(event.name) === false,
+--  }),
+--)
+++})
+```
+
+4. Remove `observer()` wrapped components and reformat as functional React components
+
+- Do a project-wide search for `observer(` and replace each component instance with the following pattern:
+
+```diff
+--import { observer } from "mobx-react-lite"
+
+--export const WelcomeScreen: FC<WelcomeScreenProps> = observer(function WelcomeScreen(props) {
+++export const WelcomeScreen: FC<WelcomeScreenProps> = (props) => {
+    ...
+--})
+++}
+```
+
+5. Update the [Ignite Generator Templates](https://docs.infinite.red/ignite-cli/concept/Generator-Templates/)!
+
+- Follow the same pattern to replace `observer()`. This will allow you to quickly generate screens and components via `npx ignite-cli generate screen NewScreen` and `npx ignite-cli generate component NewComponent` and use your updated syntax.
+- I also recommend customizing these however else you prefer!
+
+**ignite/templates/component/NAME.tsx.ejs**  
+**ignite/templates/screen/NAMEScreen.tsx.ejs**
+
+```diff
+--import { observer } from "mobx-react-lite"
+
+--export const <%= props.pascalCaseName %> = observer(function <%= props.pascalCaseName %>(props: <%= props.pascalCaseName %>Props) {
+++export const <%= props.pascalCaseName %> = (props: <%= props.pascalCaseName %>Props) => {
+    ...
+--})
+++}
+```
+
+6. Remove old Mobx-State-Tree store initialization & hydration code in `app.tsx`.
+
+- We still need to call `hideSplashScreen` in a `useEffect` so the app loads without needing to hydrate a store first.
+
+**app/app.tsx**
+
+```diff
+--import { useInitialRootStore } from "./models"
+
+--const { rehydrated } = useInitialRootStore(() => {
+--setTimeout(hideSplashScreen, 500)
+--})
+++useEffect(() => {
+++    setTimeout(hideSplashScreen, 500)
+++}, [])
+
+--if (!rehydrated || !isNavigationStateRestored || !areFontsLoaded) return null
+++if (!isNavigationStateRestored || !areFontsLoaded) return null
+```
+
+## Conclusion
+
+You should be able to build and run your app! It won't have any data...but you now have a "blank slate" to setup your state management solution of choice.
+
+For next steps, we have recipes for migrating to
+
+- [Redux](./Redux.md)
+- [Zustand](./Zustand.md)
+- Or you can roll your own!

--- a/docs/recipes/RemoveMobxStateTree.md
+++ b/docs/recipes/RemoveMobxStateTree.md
@@ -11,7 +11,7 @@ publish_date: 2024-02-05
 
 # Remove Mobx-State-Tree
 
-By default, Ignite uses [Mobx-State-Tree](https://mobx-state-tree.js.org/) as the default state management solution. While we love [Mobx-State-Tree at Infinite Red](https://docs.infinite.red/ignite-cli/concept/MobX-State-Tree/), we understand the landscape is rich with great alternatives that you may want to use instead.
+By default, Ignite uses [MobX-State-Tree](https://mobx-state-tree.js.org/) as the default state management solution. While we love [Mobx-State-Tree at Infinite Red](https://docs.infinite.red/ignite-cli/concept/MobX-State-Tree/), we understand the landscape is rich with great alternatives that you may want to use instead.
 
 This guide will show you how to remove Mobx-State-Tree from an Ignite-generated project and get to a "blank slate" with no state management at all.
 
@@ -108,7 +108,7 @@ const AppStack = () => {
 ++}
 ```
 
-7. Remove old Mobx-State-Tree store initialization & hydration code in `app.tsx`.
+7. Remove old MobX-State-Tree store initialization & hydration code in `app.tsx`.
 
 - We still need to call `hideSplashScreen` in a `useEffect` so the app loads without needing to hydrate a store first.
 

--- a/docs/recipes/Zustand.md
+++ b/docs/recipes/Zustand.md
@@ -15,7 +15,7 @@ publish_date: 2024-02-05
 [Zustand](https://github.com/pmndrs/zustand) is a "bearbones" state management solution (hence the cute bear mascot).
 Its a relatively simple and unopinionated option to manage application state, with a hooks-based API for easy use in a React app.
 
-This guide will show you how to migrate a Mobx-State-Tree project (Ignite's default) to Zustand, using a new Ignite project as an example:
+This guide will show you how to migrate a MobX-State-Tree project (Ignite's default) to Zustand, using a new Ignite project as an example:
 
 ```terminal
 npx ignite-cli new ZustandApp --yes
@@ -25,9 +25,9 @@ If you are converting an existing project these steps still apply, but you may a
 
 Check out the [Final Source Code](https://github.com/Jpoliachik/ignite-zustand) or follow along below!
 
-## Convert Mobx-State-Tree Models to Zustand
+## Convert MobX-State-Tree Models to Zustand
 
-Our Ignite Demo App includes a few Mobx-State-Tree models inside `app/models`. Before we remove those, let's convert them to Zustand!
+Our Ignite Demo App includes a few MobX-State-Tree models inside `app/models`. Before we remove those, let's convert them to Zustand!
 
 First, add `zustand`:
 
@@ -48,7 +48,7 @@ If you Ignited a demo-free project `npx ignite-cli new ZustandApp --yes --remove
 **AuthenticationStore**
 
 <details>
-<summary>For reference, here's the original AuthenticationStore with Mobx-State-Tree:</summary>
+<summary>For reference, here's the original AuthenticationStore with MobX-State-Tree:</summary>
 
 **`app/models/AuthenticationStore.ts`**
 
@@ -91,7 +91,7 @@ export interface AuthenticationStoreSnapshot extends SnapshotOut<typeof Authenti
 
 </details>
 
-Mobx-State-Tree models declare the data type, initial values, derived values, and actions all in one.  
+MobX-State-Tree models declare the data type, initial values, derived values, and actions all in one.  
 Zustand takes a "barebones" approach and defines a store as a basic state object with data and actions co-located.
 
 Create a new file `app/store/AuthenticationStore.ts` and convert the model to Zustand to look like this:
@@ -153,7 +153,7 @@ A few things to note:
 Follow the same pattern to convert `app/models/EpisodeStore.ts`
 
 <details>
-  <summary>Original Mobx-State-Tree EpisodeStore for reference:</summary>
+  <summary>Original MobX-State-Tree EpisodeStore for reference:</summary>
 
 **`app/models/EpisodeStore.ts`**
 
@@ -296,7 +296,7 @@ So far, `AuthenticationStore` and `EpisodeStore` converted cleanly into Zustand 
 - Another very popular method is to use [Zod](https://zod.dev/), which also enables data validation at runtime for better safety.
 
 <details>
-<summary>Original Mobx-State-Tree Episode.ts file for reference:</summary>
+<summary>Original MobX-State-Tree Episode.ts file for reference:</summary>
 
 **`app/models/Episode.ts`**
 
@@ -464,9 +464,9 @@ export const getDuration = (episode: Episode) => {
 
 </details>
 
-## Remove Mobx-State-Tree
+## Remove MobX-State-Tree
 
-Now that our models have been converted, follow our recipe to [Remove Mobx-State-Tree](./RemoveMobxStateTree.md) entirely from your project.
+Now that our models have been converted, follow our recipe to [Remove MobX-State-Tree](./RemoveMobxStateTree.md) entirely from your project.
 
 ## Create Store
 

--- a/docs/recipes/Zustand.md
+++ b/docs/recipes/Zustand.md
@@ -517,7 +517,7 @@ In the Ignite Demo App, we'll update the following components to use our exporte
 **`app/navigators/AppNavigator.tsx`**
 
 ```tsx
-import { useStore, isAuthenticatedSelector } from "../store";
+import { useStore, isAuthenticatedSelector } from "app/store";
 
 const AppStack = () => {
 
@@ -556,7 +556,17 @@ import {
 const episodeStore = useEpisodeStore();
 ```
 
-We also need to update how we get derived values from `Episode` now that we're working with a plain object in Zustand without custom getters. Instead of `episode.duration` we can use our util function `getDatePublished`. Add these lines to the render function of `EpisodeCard`, and replace a few spots those values are used.
+```diff
+<Toggle
+  value={episodeStore.favoritesOnly}
+  onValueChange={() =>
+--  episodeStore.setProp("favoritesOnly", !episodeStore.favoritesOnly)
+++  episodeStore.setFavoritesOnly(!episodeStore.favoritesOnly)
+  }
+
+```
+
+We also need to update how we get derived values from `Episode` now that we're working with a plain object in Zustand without custom getters. Instead of `episode.duration` we can use our util function `getDuration`. Add these lines to the render function of `EpisodeCard`, and replace a few spots those values are used.
 
 ```ts
 const datePublished = getDatePublished(episode);
@@ -581,6 +591,8 @@ A few additional updates to make in Ignite's Demo App:
 **`app/screens/WelcomeScreen.tsx`**
 
 ```diff
+++import { useStore } from "app/store"
+
 --const {
 --  authenticationStore: { logout },
 --} = useStores()
@@ -590,6 +602,8 @@ A few additional updates to make in Ignite's Demo App:
 **`app/screens/DemoDebugScreen.tsx`**
 
 ```diff
+++import { useStore } from "app/store"
+
 --const {
 --  authenticationStore: { logout },
 --} = useStores()
@@ -599,7 +613,7 @@ A few additional updates to make in Ignite's Demo App:
 **`app/services/api/api.ts`**
 
 ```diff
-+import { Episode } from "../../models/Episode";
++import { Episode } from "app/store/Episode";
 
 -const episodes: EpisodeSnapshotIn[] =
 +const episodes: Episode[] =
@@ -661,7 +675,7 @@ We added the `persist` middleware and created `_hasHydrated` property & action t
 **`app/app.tsx`**
 
 ```diff
-+import { useStore } from "./models"
++import { useStore } from "./store"
 
 ...
 

--- a/docs/recipes/Zustand.md
+++ b/docs/recipes/Zustand.md
@@ -1,0 +1,686 @@
+---
+title: Zustand
+description: How to migrate a Mobx-State-Tree project to Zustand
+tags:
+  - Zustand
+  - MobX
+  - State Management
+last_update:
+  author: Justin Poliachik
+publish_date: 2024-01-16
+---
+
+# Zustand
+
+[Zustand](https://github.com/pmndrs/zustand) is a "bearbones" state management solution (hence the cute bear mascot).
+Its a relatively simple and unopinionated option to manage application state, with a hooks-based API for easy use in a React app.
+
+This guide will show you how to migrate a Mobx-State-Tree project (Ignite's default) to Zustand, using a new Ignite project as an example:
+
+```terminal
+npx ignite-cli new ZustandApp --yes
+```
+
+If you are converting an existing project these steps still apply, but you may also need to migrate other related functionality.
+
+## Convert Mobx-State-Tree Models to Zustand
+
+Our Ignite Demo App includes a few Mobx-State-Tree models inside `app/models`. Before we remove those, let's convert them to Zustand!
+
+First, add `zustand`:
+
+```terminal
+yarn add zustand
+```
+
+Create a directory for our new Zustand store files:
+
+```terminal
+mkdir app/store
+```
+
+:::note
+If you Ignited a demo-free project `npx ignite-cli new ZustandApp --yes --removeDemo` or if you don't have any existing models to convert and you're already familiar with Zustand, feel free to [skip this section](#remove-mobx-state-tree).
+:::
+
+**AuthenticationStore**
+
+<details>
+<summary>For reference, here's the original AuthenticationStore with Mobx-State-Tree:</summary>
+
+**`app/models/AuthenticationStore.ts`**
+
+```ts
+import { Instance, SnapshotOut, types } from "mobx-state-tree";
+
+export const AuthenticationStoreModel = types
+  .model("AuthenticationStore")
+  .props({
+    authToken: types.maybe(types.string),
+    authEmail: "",
+  })
+  .views((store) => ({
+    get isAuthenticated() {
+      return !!store.authToken;
+    },
+    get validationError() {
+      if (store.authEmail.length === 0) return "can't be blank";
+      if (store.authEmail.length < 6) return "must be at least 6 characters";
+      if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(store.authEmail)) return "must be a valid email address";
+      return "";
+    },
+  }))
+  .actions((store) => ({
+    setAuthToken(value?: string) {
+      store.authToken = value;
+    },
+    setAuthEmail(value: string) {
+      store.authEmail = value.replace(/ /g, "");
+    },
+    logout() {
+      store.authToken = undefined;
+      store.authEmail = "";
+    },
+  }));
+
+export interface AuthenticationStore extends Instance<typeof AuthenticationStoreModel> {}
+export interface AuthenticationStoreSnapshot extends SnapshotOut<typeof AuthenticationStoreModel> {}
+```
+
+</details>
+
+Mobx-State-Tree models declare the data type, initial values, derived values, and actions all in one.  
+Zustand takes a "barebones" approach and defines a store as a basic state object with data and actions co-located.
+
+Create a new file `app/store/AuthenticationStore.ts` and convert the model to Zustand to look like this:
+
+**`app/store/AuthenticationStore.ts`**
+
+```ts
+import { StateCreator } from "zustand";
+import { RootStore } from "./RootStore";
+
+// Typescript interface for this store slice
+export interface AuthenticationStore {
+  authToken?: string;
+  authEmail: string;
+  setAuthToken: (value?: string) => void;
+  setAuthEmail: (value: string) => void;
+  logout: () => void;
+}
+
+// create our store slice with default data and actions
+export const createAuthenticationSlice: StateCreator<RootStore, [], [], AuthenticationStore> = (set) => ({
+  authToken: undefined,
+  authEmail: "",
+  setAuthToken: (value) => set({ authToken: value }),
+  setAuthEmail: (value) => set({ authEmail: value.replace(/ /g, "") }),
+  logout: () => set({ authToken: undefined, authEmail: "" }),
+});
+
+// a selector can be used to grab the full AuthenticationStore
+export const authenticationStoreSelector = (state: RootStore) => ({
+  authToken: state.authToken,
+  authEmail: state.authEmail,
+  isAuthenticated: isAuthenticatedSelector(state),
+  setAuthToken: state.setAuthToken,
+  setAuthEmail: state.setAuthEmail,
+  logout: state.logout,
+});
+
+// selectors can also be used for derived values
+export const isAuthenticatedSelector = (state: RootStore) => !!state.authToken;
+
+export const validationErrorSelector = (state: RootStore) => {
+  if (state.authEmail.length === 0) return "can't be blank";
+  if (state.authEmail.length < 6) return "must be at least 6 characters";
+  if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(state.authEmail)) return "must be a valid email address";
+  return "";
+};
+```
+
+A few things to note:
+
+- We're using the [slices pattern](https://github.com/pmndrs/zustand/blob/main/docs/guides/slices-pattern.md) to create AuthenticationStore as a slice of the overall state.
+- Zustand doesn't validate data, so we need to explicitly define the Typescript interface `AuthenticationStore`.
+- We've created several selectors for our derived values. These can be chained together, or used directly in a component via `useStore(mySelector)`. You'll see how these are used in components later.
+- Zustand is very non-opinionated, so there are many different ways to achieve this! Keep this in mind if your app has different use cases, or if you'd like to experiment with alternative strategies for creating your stores.
+
+**EpisodeStore**
+
+Follow the same pattern to convert `app/models/EpisodeStore.ts`
+
+<details>
+  <summary>Original Mobx-State-Tree EpisodeStore for reference:</summary>
+
+**`app/models/EpisodeStore.ts`**
+
+```ts
+import { Instance, SnapshotOut, types } from "mobx-state-tree";
+import { api } from "../services/api";
+import { Episode, EpisodeModel } from "./Episode";
+import { withSetPropAction } from "./helpers/withSetPropAction";
+
+export const EpisodeStoreModel = types
+  .model("EpisodeStore")
+  .props({
+    episodes: types.array(EpisodeModel),
+    favorites: types.array(types.reference(EpisodeModel)),
+    favoritesOnly: false,
+  })
+  .actions(withSetPropAction)
+  .actions((store) => ({
+    async fetchEpisodes() {
+      const response = await api.getEpisodes();
+      if (response.kind === "ok") {
+        store.setProp("episodes", response.episodes);
+      } else {
+        console.error(`Error fetching episodes: ${JSON.stringify(response)}`);
+      }
+    },
+    addFavorite(episode: Episode) {
+      store.favorites.push(episode);
+    },
+    removeFavorite(episode: Episode) {
+      store.favorites.remove(episode);
+    },
+  }))
+  .views((store) => ({
+    get episodesForList() {
+      return store.favoritesOnly ? store.favorites : store.episodes;
+    },
+
+    hasFavorite(episode: Episode) {
+      return store.favorites.includes(episode);
+    },
+  }))
+  .actions((store) => ({
+    toggleFavorite(episode: Episode) {
+      if (store.hasFavorite(episode)) {
+        store.removeFavorite(episode);
+      } else {
+        store.addFavorite(episode);
+      }
+    },
+  }));
+
+export interface EpisodeStore extends Instance<typeof EpisodeStoreModel> {}
+export interface EpisodeStoreSnapshot extends SnapshotOut<typeof EpisodeStoreModel> {}
+```
+
+</details>
+
+<details>
+<summary>Converted EpisodeStore using Zustand:</summary>
+
+**`app/store/EpisodeStore.ts`**
+
+```ts
+import { api } from "../services/api";
+import { Episode } from "./Episode";
+import { StateCreator } from "zustand";
+import { RootStore } from "./RootStore";
+
+export interface EpisodeStore {
+  episodes: Episode[];
+  favorites: string[];
+  favoritesOnly: boolean;
+
+  fetchEpisodes: () => Promise<void>;
+  addFavorite: (episode: Episode) => void;
+  removeFavorite: (episode: Episode) => void;
+  toggleFavorite: (episode: Episode) => void;
+  setFavoritesOnly: (value: boolean) => void;
+}
+
+export const createEpisodeSlice: StateCreator<RootStore, [], [], EpisodeStore> = (set, get) => ({
+  episodes: [],
+  favorites: [],
+  favoritesOnly: false,
+
+  // Zustand supports async actions
+  fetchEpisodes: async () => {
+    const response = await api.getEpisodes();
+    if (response.kind === "ok") {
+      set({ episodes: response.episodes });
+    } else {
+      console.error(`Error fetching episodes: ${JSON.stringify(response)}`);
+    }
+  },
+  addFavorite: (episode) => set((state) => ({ favorites: [...state.favorites, episode.guid] })),
+  removeFavorite: (episode) => set((state) => ({ favorites: state.favorites.filter((guid) => guid !== episode.guid) })),
+  toggleFavorite: (episode) => {
+    // get() can be used within actions
+    if (get().favorites.includes(episode.guid)) {
+      get().removeFavorite(episode);
+    } else {
+      get().addFavorite(episode);
+    }
+  },
+  setFavoritesOnly: (value: boolean) => set({ favoritesOnly: value }),
+});
+
+export const episodeStoreSelector = (state: RootStore) => ({
+  episodes: state.episodes,
+  favorites: state.favorites,
+  favoritesOnly: state.favoritesOnly,
+
+  // derived values can be included in selectors like this
+  episodesForList: getEpisodesForList(state),
+
+  fetchEpisodes: state.fetchEpisodes,
+  addFavorite: state.addFavorite,
+  removeFavorite: state.removeFavorite,
+  toggleFavorite: state.toggleFavorite,
+  setFavoritesOnly: state.setFavoritesOnly,
+
+  // we can also include helper functions that have access to state
+  hasFavorite: (episode: Episode) => {
+    return state.favorites.includes(episode.guid);
+  },
+});
+
+export const getEpisodesForList = (store: EpisodeStore) => {
+  return store.favoritesOnly ? store.episodes.filter((a) => store.favorites.includes(a.guid)) : store.episodes;
+};
+```
+
+</details>
+
+**Episode**
+
+So far, `AuthenticationStore` and `EpisodeStore` converted cleanly into Zustand store slices. But we also have `app/models/Episode.ts`, which is less of a data store and more of a basic data model. We don't need a Zustand slice for `Episode`, and Zustand is not opinionated about how data models are defined, so let's convert this into a set of Typescript types to define the data model and a few basic util functions for the derived values.
+
+- Another very popular method is to use [Zod](https://zod.dev/), which also enables data validation at runtime for better safety.
+
+<details>
+<summary>Original Mobx-State-Tree Episode.ts file for reference:</summary>
+
+**`app/models/Episode.ts`**
+
+```ts
+import { Instance, SnapshotIn, SnapshotOut, types } from "mobx-state-tree";
+import { withSetPropAction } from "./helpers/withSetPropAction";
+import { formatDate } from "../utils/formatDate";
+import { translate } from "../i18n";
+
+interface Enclosure {
+  link: string;
+  type: string;
+  length: number;
+  duration: number;
+  rating: { scheme: string; value: string };
+}
+
+/**
+ * This represents an episode of React Native Radio.
+ */
+export const EpisodeModel = types
+  .model("Episode")
+  .props({
+    guid: types.identifier,
+    title: "",
+    pubDate: "", // Ex: 2022-08-12 21:05:36
+    link: "",
+    author: "",
+    thumbnail: "",
+    description: "",
+    content: "",
+    enclosure: types.frozen<Enclosure>(),
+    categories: types.array(types.string),
+  })
+  .actions(withSetPropAction)
+  .views((episode) => ({
+    get parsedTitleAndSubtitle() {
+      const defaultValue = { title: episode.title?.trim(), subtitle: "" };
+
+      if (!defaultValue.title) return defaultValue;
+
+      const titleMatches = defaultValue.title.match(/^(RNR.*\d)(?: - )(.*$)/);
+
+      if (!titleMatches || titleMatches.length !== 3) return defaultValue;
+
+      return { title: titleMatches[1], subtitle: titleMatches[2] };
+    },
+    get datePublished() {
+      try {
+        const formatted = formatDate(episode.pubDate);
+        return {
+          textLabel: formatted,
+          accessibilityLabel: translate("demoPodcastListScreen.accessibility.publishLabel", {
+            date: formatted,
+          }),
+        };
+      } catch (error) {
+        return { textLabel: "", accessibilityLabel: "" };
+      }
+    },
+    get duration() {
+      const seconds = Number(episode.enclosure.duration);
+      const h = Math.floor(seconds / 3600);
+      const m = Math.floor((seconds % 3600) / 60);
+      const s = Math.floor((seconds % 3600) % 60);
+
+      const hDisplay = h > 0 ? `${h}:` : "";
+      const mDisplay = m > 0 ? `${m}:` : "";
+      const sDisplay = s > 0 ? s : "";
+      return {
+        textLabel: hDisplay + mDisplay + sDisplay,
+        accessibilityLabel: translate("demoPodcastListScreen.accessibility.durationLabel", {
+          hours: h,
+          minutes: m,
+          seconds: s,
+        }),
+      };
+    },
+  }));
+
+export interface Episode extends Instance<typeof EpisodeModel> {}
+export interface EpisodeSnapshotOut extends SnapshotOut<typeof EpisodeModel> {}
+export interface EpisodeSnapshotIn extends SnapshotIn<typeof EpisodeModel> {}
+```
+
+</details>
+
+<details>
+<summary>
+Updated Episode.ts model using Typescript types and util functions
+</summary>
+
+**`app/store/Episode.ts`**
+
+```ts
+import { formatDate } from "../utils/formatDate";
+import { translate } from "../i18n";
+
+interface Enclosure {
+  link: string;
+  type: string;
+  length: number;
+  duration: number;
+  rating: { scheme: string; value: string };
+}
+
+export type Episode = {
+  guid: string;
+  title: string;
+  pubDate: string;
+  link: string;
+  author: string;
+  thumbnail: string;
+  description: string;
+  content: string;
+  enclosure: Enclosure;
+  categories: string[];
+};
+
+export const getParsedTitleAndSubtitle = (episode: Episode) => {
+  const defaultValue = { title: episode.title?.trim(), subtitle: "" };
+
+  if (!defaultValue.title) return defaultValue;
+
+  const titleMatches = defaultValue.title.match(/^(RNR.*\d)(?: - )(.*$)/);
+
+  if (!titleMatches || titleMatches.length !== 3) return defaultValue;
+
+  return { title: titleMatches[1], subtitle: titleMatches[2] };
+};
+
+export const getDatePublished = (episode: Episode) => {
+  try {
+    const formatted = formatDate(episode.pubDate);
+    return {
+      textLabel: formatted,
+      accessibilityLabel: translate("demoPodcastListScreen.accessibility.publishLabel", {
+        date: formatted,
+      }),
+    };
+  } catch (error) {
+    return { textLabel: "", accessibilityLabel: "" };
+  }
+};
+
+export const getDuration = (episode: Episode) => {
+  const seconds = Number(episode.enclosure.duration);
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  const s = Math.floor((seconds % 3600) % 60);
+
+  const hDisplay = h > 0 ? `${h}:` : "";
+  const mDisplay = m > 0 ? `${m}:` : "";
+  const sDisplay = s > 0 ? s : "";
+  return {
+    textLabel: hDisplay + mDisplay + sDisplay,
+    accessibilityLabel: translate("demoPodcastListScreen.accessibility.durationLabel", {
+      hours: h,
+      minutes: m,
+      seconds: s,
+    }),
+  };
+};
+```
+
+</details>
+
+## Remove Mobx-State-Tree
+
+Now that our models have been converted, follow our recipe to [Remove Mobx-State-Tree](./RemoveMobxStateTree.md) entirely from your project.
+
+## Create Store
+
+Let's create our main Zustand store. Create a new file `app/store/RootStore.ts`:
+
+**`app/store/RootStore.ts`**
+
+```ts
+import { create } from "zustand";
+import { useShallow } from "zustand/react/shallow";
+import { AuthenticationStore, authenticationStoreSelector, createAuthenticationSlice } from "./AuthenticationStore";
+import { EpisodeStore, createEpisodeSlice, episodeStoreSelector } from "./EpisodeStore";
+
+export interface RootStore extends AuthenticationStore, EpisodeStore {}
+
+export const useStore = create<RootStore>()((...a) => ({
+  ...createAuthenticationSlice(...a),
+  ...createEpisodeSlice(...a),
+  // add your state slices here
+}));
+
+// optional: custom hooks can be used to pick pieces from state
+// useShallow is used to help prevent unnecessary rerenders
+export const useAuthenticationStore = () => useStore(useShallow(authenticationStoreSelector));
+export const useEpisodeStore = () => useStore(useShallow(episodeStoreSelector));
+```
+
+- We're combining AuthenticationStore and EpisodeStore into one Zustand store for simplicity. Again, Zustand is very non-opinionated so you can modify this structure if desired.
+- `useAuthenticationStore` and `useEpisodeStore` are exported as custom hooks to make it easier to select common pieces of state. Feel free to create additional custom hooks for reusable lookup patterns and prevent unnecessary re-renders [Read more about this](https://github.com/pmndrs/zustand?tab=readme-ov-file#selecting-multiple-state-slices).
+
+Create `store/index.ts` file to export our hooks and selectors for easy use across our app:
+
+**`app/store/index.ts`**
+
+```ts
+export * from "./RootStore";
+export * from "./AuthenticationStore";
+export * from "./EpisodeStore";
+export * from "./Episode";
+```
+
+## Use Zustand in Components
+
+Zustand's hooks-based API makes it easy to pull data into components.
+
+In the Ignite Demo App, we'll update the following components to use our exported Zustand hooks and selectors:
+
+**`app/navigators/AppNavigator.tsx`**
+
+```tsx
+import { useStore, isAuthenticatedSelector } from "../store";
+
+const AppStack = () => {
+
+  // use a selector to pick only that value
+  const isAuthenticated = useStore(isAuthenticatedSelector)
+
+  return (
+    <Stack.Navigator
+    ...
+```
+
+**`app/screens/LoginScreen.tsx`**
+
+```tsx
+// pick several values & actions from the AuthenticationStore
+const { authEmail, setAuthEmail, setAuthToken } = useAuthenticationStore();
+// we can also use multiple hooks
+const validationError = useStore(validationErrorSelector);
+```
+
+**`app/screens/DemoPodcastListScreen.tsx`**
+
+Several changes are needed here. We'll use `useEpisodeStore` to select all the data and actions we need from EpisodeStore:
+
+```ts
+import {
+  useEpisodeStore,
+  Episode,
+  getDatePublished,
+  getDuration,
+  getParsedTitleAndSubtitle,
+} from "app/store"
+
+...
+
+const episodeStore = useEpisodeStore();
+```
+
+We also need to update how we get derived values from `Episode` now that we're working with a plain object in Zustand without custom getters. Instead of `episode.duration` we can use our util function `getDatePublished`. Add these lines to the render function of `EpisodeCard`, and replace a few spots those values are used.
+
+```ts
+const datePublished = getDatePublished(episode);
+const duration = getDuration(episode);
+const parsedTitleAndSubtitle = getParsedTitleAndSubtitle(episode);
+```
+
+```diff
+ <Text
+  style={$metadataText}
+  size="xxs"
+--accessibilityLabel={episode.datePublished.accessibilityLabel}
+++accessibilityLabel={datePublished.accessibilityLabel}
+>
+--{episode.datePublished.textLabel}
+++{datePublished.textLabel}
+</Text>
+```
+
+A few additional updates to make in Ignite's Demo App:
+
+**`app/screens/WelcomeScreen.tsx`**
+
+```diff
+--const {
+--  authenticationStore: { logout },
+--} = useStores()
+++const logout = useStore((state) => state.logout)
+```
+
+**`app/screens/DemoDebugScreen.tsx`**
+
+```diff
+--const {
+--  authenticationStore: { logout },
+--} = useStores()
+++const logout = useStore((state) => state.logout)
+```
+
+**`app/services/api/api.ts`**
+
+```diff
++import { Episode } from "../../models/Episode";
+
+-const episodes: EpisodeSnapshotIn[] =
++const episodes: Episode[] =
+```
+
+## Persist Zustand Store
+
+Zustand ships with [persistence middlware](https://github.com/pmndrs/zustand/blob/main/docs/integrations/persisting-store-data.md). Let's hook it up!
+
+Update `RootStore` to look like this:
+
+**`app/store/RootStore.ts`**
+
+```ts
+import { create } from "zustand";
+import { useShallow } from "zustand/react/shallow";
+import { persist, createJSONStorage } from "zustand/middleware";
+
+import { AuthenticationStore, authenticationStoreSelector, createAuthenticationSlice } from "./AuthenticationStore";
+import { EpisodeStore, createEpisodeSlice, episodeStoreSelector } from "./EpisodeStore";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+
+export interface RootStore extends AuthenticationStore, EpisodeStore {
+  _hasHydrated: boolean;
+  setHasHydrated: (state: boolean) => void;
+}
+
+export const useStore = create<RootStore>()(
+  persist(
+    (...a) => ({
+      ...createAuthenticationSlice(...a),
+      ...createEpisodeSlice(...a),
+      // add your state slices here
+
+      _hasHydrated: false,
+      setHasHydrated: (state) => {
+        const set = a[0];
+        set({
+          _hasHydrated: state,
+        });
+      },
+    }),
+    {
+      name: "zustand-app",
+      storage: createJSONStorage(() => AsyncStorage),
+      onRehydrateStorage: () => (state) => {
+        state?.setHasHydrated(true);
+      },
+    }
+  )
+);
+
+export const useAuthenticationStore = () => useStore(useShallow(authenticationStoreSelector));
+export const useEpisodeStore = () => useStore(useShallow(episodeStoreSelector));
+```
+
+We added the `persist` middleware and created `_hasHydrated` property & action to track `AsyncStorage` hydration. This will automatically persist and hydrate your Zustand store! We just need to handle the loading state during initial hydration:
+
+**`app/app.tsx`**
+
+```diff
++import { useStore } from "./models"
+
+...
+
+const [areFontsLoaded] = useFonts(customFontsToLoad)
+
+-useEffect(() => {
+-  hideSplashScreen()
+-}, [])
+
++const hasHydrated = useStore((state) => state._hasHydrated)
++useEffect(() => {
++  if (hasHydrated) {
++    setTimeout(hideSplashScreen, 500)
++  }
++}, [hasHydrated])
+
+-if (!isNavigationStateRestored || !areFontsLoaded) return null
++if (!hasHydrated || !isNavigationStateRestored || !areFontsLoaded) return null
+
+```
+
+And we're all set!
+
+[Full Source Code](https://github.com/Jpoliachik/ignite-zustand)

--- a/docs/recipes/Zustand.md
+++ b/docs/recipes/Zustand.md
@@ -7,7 +7,7 @@ tags:
   - State Management
 last_update:
   author: Justin Poliachik
-publish_date: 2024-01-16
+publish_date: 2024-02-05
 ---
 
 # Zustand
@@ -22,6 +22,8 @@ npx ignite-cli new ZustandApp --yes
 ```
 
 If you are converting an existing project these steps still apply, but you may also need to migrate other related functionality.
+
+Check out the [Final Source Code](https://github.com/Jpoliachik/ignite-zustand) or follow along below!
 
 ## Convert Mobx-State-Tree Models to Zustand
 


### PR DESCRIPTION
I added a new recipe for migrating to Zustand and refactored the steps to remove Mobx-State-Tree out of the Redux post to be shared by both. 

The Redux recipe followed a `--removeDemo` project which was much simpler to convert. For Zustand I followed the Ignite Demo project, so this post includes a lot more detail on the actual process of converting models & state to Zustand. 
Open to thoughts on this - including the demo offers opportunity to learn about the differences between MST and Zustand, but it also adds a lot of extra length to this post which could be confusing for those starting from a demoless project. 