### PR TITLE
fix: metadata plugin should take first found result 

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -76,19 +76,19 @@ const config = {
             let recordContents = false;
             for await (const line of rl) {
               // extract author
-              if (/author:/.test(line)) {
+              if (!author && /author:/.test(line)) {
                 author = line.split(":")[1].trim();
                 continue;
               }
 
               // extract title
-              if (/title:/.test(line)) {
+              if (!title && /title:/.test(line)) {
                 title = line.split(":")[1].trim();
                 continue;
               }
 
               // extract publish_date
-              if (/publish_date:/.test(line)) {
+              if (!publish_date && /publish_date:/.test(line)) {
                 publish_date = line.split(":")[1].trim();
                 continue;
               }


### PR DESCRIPTION
Issue on current site: documents often return incorrect `title`, because the code to find metadata ends with the _last_ found result of `title: x`. 
<img width="817" alt="image" src="https://github.com/infinitered/ignite-cookbook/assets/5148640/0e1b2569-1870-47dc-b29f-64c58f29911f">

Several docs we have sample code that cause incorrect results, eg: 
```
reactotron.onCustomCommand({
  title: "Go Back",
  description: "Goes back",
  command: "goBack",
```

This fix makes sure we only grab the first result found, which should always be at the top of a doc: 
```
---
title: Expo Router
description: How to convert Ignite v9 demo app to utilize `expo-router`
tags:
  - Expo
  - expo-router
  - react-navigation
last_update:
  author: Frank Calise & Justin Poliachik
publish_date: 2024-01-25
---
```

Screenshot after fix: 
<img width="661" alt="image" src="https://github.com/infinitered/ignite-cookbook/assets/5148640/da4471f9-9b8e-4c96-993b-2ab8b4d654d4">

