### PR TITLE
Updates the "Latest Release" section dynamically check for latest version

### DIFF
--- a/src/components/LatestVersion/index.tsx
+++ b/src/components/LatestVersion/index.tsx
@@ -21,7 +21,7 @@ const LatestRelease = () => {
       .then((data: Release) => {
         setLatestReleaseDate(data.published_at);
         setLatestVersion(data.tag_name);
-        setLoading(false);
+        // setLoading(false);
       })
       .catch((error) => console.error("Error fetching latest release:", error));
   }, []);
@@ -31,12 +31,18 @@ const LatestRelease = () => {
 
   return (
     <div>
-      <p className={styles.notificationTagText}>Latest Release</p>
-      <h3 className={styles.notificationTitle}>Ignite Exp[ress]o ☕️</h3>
+      <p className={styles.notificationTagText}>Latest Ignite Release</p>
       {loading ? (
-        <b style={{ margin: 10 }}>Checking...</b>
+        <Link
+          className={styles.notificationLink}
+          href={`https://github.com/infinitered/ignite/releases/latest`}
+        >
+          <b className={styles.notificationLinkText}>View on Github</b>
+          <Arrow.default />
+        </Link>
       ) : (
         <>
+          <h3 className={styles.notificationTitle}>Ignite Exp[ress]o ☕️</h3>
           <p className={styles.notificationDate}>
             {daysSinceRelease === 0 ? (
               <>

--- a/src/components/LatestVersion/index.tsx
+++ b/src/components/LatestVersion/index.tsx
@@ -1,0 +1,67 @@
+import React, { useState, useEffect } from "react";
+import Link from "@docusaurus/Link";
+import moment from "moment";
+
+import styles from "../../pages/index.module.css";
+import * as Arrow from "@site/static/img/arrow.svg";
+
+interface Release {
+  tag_name: string;
+  published_at: string;
+}
+
+const LatestRelease = () => {
+  const [latestVersion, setLatestVersion] = useState<string>("");
+  const [latestReleaseDate, setLatestReleaseDate] = useState<string>("");
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetch("https://api.github.com/repos/infinitered/ignite/releases/latest")
+      .then((response) => response.json())
+      .then((data: Release) => {
+        setLatestReleaseDate(data.published_at);
+        setLatestVersion(data.tag_name);
+        setLoading(false);
+      })
+      .catch((error) => console.error("Error fetching latest release:", error));
+  }, []);
+
+  const daysSinceRelease =
+    moment(latestReleaseDate).diff(moment(), "days") * -1;
+
+  return (
+    <div>
+      <p className={styles.notificationTagText}>Latest Release</p>
+      <h3 className={styles.notificationTitle}>Ignite Exp[ress]o ☕️</h3>
+      {loading ? (
+        <b style={{ margin: 10 }}>Checking...</b>
+      ) : (
+        <>
+          <p className={styles.notificationDate}>
+            {daysSinceRelease === 0 ? (
+              <>
+                <b>{latestVersion}</b> released today!
+              </>
+            ) : (
+              <>
+                <b>{latestVersion}</b> released{" "}
+                <b>
+                  {daysSinceRelease} day{daysSinceRelease === 1 ? "" : "s"} ago
+                </b>
+              </>
+            )}
+          </p>
+          <Link
+            className={styles.notificationLink}
+            href={`https://github.com/infinitered/ignite/releases/tag/${latestVersion}`}
+          >
+            <b className={styles.notificationLinkText}>View on Github</b>
+            <Arrow.default />
+          </Link>
+        </>
+      )}
+    </div>
+  );
+};
+
+export default LatestRelease;

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -60,9 +60,8 @@
   height: 96px;
   padding: 12px 48px;
   box-shadow: none;
-
-
 }
+
 .navbar__logo {
   height: 48px;
 }

--- a/src/pages/index.module.css
+++ b/src/pages/index.module.css
@@ -16,6 +16,8 @@
 
  .notificationSection {
   margin-bottom: 20px;
+  min-height: 125px;
+  min-width: 210px;
  }
 
  .notificationTag {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -9,6 +9,7 @@ import styles from "./index.module.css";
 import SVGImage from "../components/SVGImage";
 import { usePluginData } from "@docusaurus/useGlobalData";
 import * as Arrow from "@site/static/img/arrow.svg";
+import LatestRelease from "../components/LatestVersion";
 
 const heroImage = require("@site/static/img/hero-graphic.svg");
 const faceWinking = require("@site/static/img/face-winking.png");
@@ -28,9 +29,6 @@ const NewSection = () => {
     (a, b) =>
       new Date(b.publish_date).getTime() - new Date(a.publish_date).getTime()
   )[0];
-
-  const igniteReleaseVersion = "v9.6.1";
-  const igniteReleaseDate = moment("2024-02-21").diff(moment(), "days") * -1;
 
   return (
     <div className={styles.newSection}>
@@ -54,27 +52,7 @@ const NewSection = () => {
         </Link>
       </div>
       <div className={styles.notificationSection}>
-        <p className={styles.notificationTagText}>Releases</p>
-        <h3 className={styles.notificationTitle}>Ignite Exp[ress]o ☕️</h3>
-        <p className={styles.notificationDate}>
-          {igniteReleaseDate > 0 ? (
-            <>
-              <b>{igniteReleaseVersion}</b> released{" "}
-              <b>{igniteReleaseDate} days ago</b>
-            </>
-          ) : (
-            <>
-              <b>{igniteReleaseVersion}</b> released today!
-            </>
-          )}
-        </p>
-        <Link
-          className={styles.notificationLink}
-          href={`https://github.com/infinitered/ignite/releases/tag/${igniteReleaseVersion}`}
-        >
-          <b className={styles.notificationLinkText}>View on Github</b>
-          <Arrow.default />
-        </Link>
+        <LatestRelease />
       </div>
     </div>
   );
@@ -132,9 +110,10 @@ function FreshRecipes() {
   return (
     <div className={styles.freshSection}>
       <p className={styles.freshSectionHeader}>Freshly added to the cookbook</p>
-      {mostRecentRecipes.slice(0, 4).map((recipe) => {
+      {mostRecentRecipes.slice(0, 4).map((recipe, index) => {
         return (
           <Link
+            key={index}
             to={`/docs/recipes/${recipe.doc_name.split(".")[0]}`}
             className={styles.recipeWrapper}
           >

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -29,8 +29,8 @@ const NewSection = () => {
       new Date(b.publish_date).getTime() - new Date(a.publish_date).getTime()
   )[0];
 
-  const igniteReleaseVersion = "v9.0.5";
-  const igniteReleaseDate = moment("2023-12-02").diff(moment(), "days") * -1;
+  const igniteReleaseVersion = "v9.6.1";
+  const igniteReleaseDate = moment("2024-02-21").diff(moment(), "days") * -1;
 
   return (
     <div className={styles.newSection}>


### PR DESCRIPTION
While investigating the process of integrating a GH Action or something like [badge-fury](https://badge.fury.io/for/js/ignite-cli), I had the thought, why don't we just hit the GH API for the latest release of Ignite?