### PR TITLE
Dynamically display ignite release versions

### DIFF
--- a/docs/recipes/SampleYAMLCircleCI.md
+++ b/docs/recipes/SampleYAMLCircleCI.md
@@ -9,7 +9,7 @@ last_update:
 publish_date: 2022-10-09
 ---
 
-### Sampl YAML File
+### Sample YAML File
 
 ```yaml
 # Javascript Node CircleCI 2.0 configuration file

--- a/src/components/LatestVersion/index.tsx
+++ b/src/components/LatestVersion/index.tsx
@@ -23,9 +23,9 @@ const ReleaseRemark = ({
   const daysSinceRelease =
     moment(latestReleaseDate).diff(moment(), "days") * -1;
   const releaseString =
-    daysSinceRelease === 0
+    daysSinceRelease !== 0
       ? "today"
-      : `${daysSinceRelease} day${daysSinceRelease === 1 ? "" : "s"} ago`;
+      : `${moment.duration(daysSinceRelease, "days").humanize()} ago`;
   return (
     <>
       <b>{latestVersion}</b> released <b>{releaseString}</b>

--- a/src/components/LatestVersion/index.tsx
+++ b/src/components/LatestVersion/index.tsx
@@ -1,0 +1,73 @@
+import React, { useState, useEffect } from "react";
+import Link from "@docusaurus/Link";
+import moment from "moment";
+
+import styles from "../../pages/index.module.css";
+import * as Arrow from "@site/static/img/arrow.svg";
+
+interface Release {
+  tag_name: string;
+  published_at: string;
+}
+
+const LatestRelease = () => {
+  const [latestVersion, setLatestVersion] = useState<string>("");
+  const [latestReleaseDate, setLatestReleaseDate] = useState<string>("");
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetch("https://api.github.com/repos/infinitered/ignite/releases/latest")
+      .then((response) => response.json())
+      .then((data: Release) => {
+        setLatestReleaseDate(data.published_at);
+        setLatestVersion(data.tag_name);
+        setLoading(false);
+      })
+      .catch((error) => console.error("Error fetching latest release:", error));
+  }, []);
+
+  const daysSinceRelease =
+    moment(latestReleaseDate).diff(moment(), "days") * -1;
+
+  return (
+    <>
+      <p className={styles.notificationTagText}>Latest Ignite Release</p>
+      {loading ? (
+        <Link
+          className={styles.notificationLink}
+          href={`https://github.com/infinitered/ignite/releases/latest`}
+        >
+          <b className={styles.notificationLinkText}>View on Github</b>
+          <Arrow.default />
+        </Link>
+      ) : (
+        <>
+          <h3 className={styles.notificationTitle}>Ignite Exp[ress]o ☕️</h3>
+          <p className={styles.notificationDate}>
+            {daysSinceRelease === 0 ? (
+              <>
+                <b>{latestVersion}</b> released today!
+              </>
+            ) : (
+              <>
+                <b>{latestVersion}</b> released{" "}
+                <b>
+                  {daysSinceRelease} day{daysSinceRelease === 1 ? "" : "s"} ago
+                </b>
+              </>
+            )}
+          </p>
+          <Link
+            className={styles.notificationLink}
+            href={`https://github.com/infinitered/ignite/releases/tag/${latestVersion}`}
+          >
+            <b className={styles.notificationLinkText}>View on Github</b>
+            <Arrow.default />
+          </Link>
+        </>
+      )}
+    </>
+  );
+};
+
+export default LatestRelease;

--- a/src/components/LatestVersion/index.tsx
+++ b/src/components/LatestVersion/index.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from "react";
 import Link from "@docusaurus/Link";
 import moment from "moment";
 
+// Bringing in the styles from the `pages/index.module.css` file to not have to duplicate the styles (nothing is new in this component)
 import styles from "../../pages/index.module.css";
 import * as Arrow from "@site/static/img/arrow.svg";
 

--- a/src/components/LatestVersion/index.tsx
+++ b/src/components/LatestVersion/index.tsx
@@ -11,6 +11,28 @@ interface Release {
   published_at: string;
 }
 
+interface ReleaseRemarkProps {
+  latestVersion: string;
+  latestReleaseDate: string;
+}
+
+const ReleaseRemark = ({
+  latestVersion,
+  latestReleaseDate,
+}: ReleaseRemarkProps) => {
+  const daysSinceRelease =
+    moment(latestReleaseDate).diff(moment(), "days") * -1;
+  const releaseString =
+    daysSinceRelease === 0
+      ? "today"
+      : `${daysSinceRelease} day${daysSinceRelease === 1 ? "" : "s"} ago`;
+  return (
+    <>
+      <b>{latestVersion}</b> released <b>{releaseString}</b>
+    </>
+  );
+};
+
 const LatestRelease = () => {
   const [latestVersion, setLatestVersion] = useState<string>("");
   const [latestReleaseDate, setLatestReleaseDate] = useState<string>("");
@@ -27,9 +49,6 @@ const LatestRelease = () => {
       .catch((error) => console.error("Error fetching latest release:", error));
   }, []);
 
-  const daysSinceRelease =
-    moment(latestReleaseDate).diff(moment(), "days") * -1;
-
   return (
     <>
       <p className={styles.notificationTagText}>Latest Ignite Release</p>
@@ -45,18 +64,10 @@ const LatestRelease = () => {
         <>
           <h3 className={styles.notificationTitle}>Ignite</h3>
           <p className={styles.notificationDate}>
-            {daysSinceRelease === 0 ? (
-              <>
-                <b>{latestVersion}</b> released today!
-              </>
-            ) : (
-              <>
-                <b>{latestVersion}</b> released{" "}
-                <b>
-                  {daysSinceRelease} day{daysSinceRelease === 1 ? "" : "s"} ago
-                </b>
-              </>
-            )}
+            <ReleaseRemark
+              latestVersion={latestVersion}
+              latestReleaseDate={latestReleaseDate}
+            />
           </p>
           <Link
             className={styles.notificationLink}

--- a/src/components/LatestVersion/index.tsx
+++ b/src/components/LatestVersion/index.tsx
@@ -43,7 +43,7 @@ const LatestRelease = () => {
         </Link>
       ) : (
         <>
-          <h3 className={styles.notificationTitle}>Ignite Exp[ress]o ☕️</h3>
+          <h3 className={styles.notificationTitle}>Ignite</h3>
           <p className={styles.notificationDate}>
             {daysSinceRelease === 0 ? (
               <>

--- a/src/pages/index.module.css
+++ b/src/pages/index.module.css
@@ -16,6 +16,8 @@
 
  .notificationSection {
   margin-bottom: 20px;
+  min-width: 220px !important;
+  min-height: 130px !important;
  }
 
  .notificationTag {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -110,10 +110,10 @@ function FreshRecipes() {
   return (
     <div className={styles.freshSection}>
       <p className={styles.freshSectionHeader}>Freshly added to the cookbook</p>
-      {mostRecentRecipes.slice(0, 4).map((recipe, index) => {
+      {mostRecentRecipes.slice(0, 4).map((recipe) => {
         return (
           <Link
-            key={index}
+            key={recipe.doc_name}
             to={`/docs/recipes/${recipe.doc_name.split(".")[0]}`}
             className={styles.recipeWrapper}
           >

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -110,9 +110,10 @@ function FreshRecipes() {
   return (
     <div className={styles.freshSection}>
       <p className={styles.freshSectionHeader}>Freshly added to the cookbook</p>
-      {mostRecentRecipes.slice(0, 4).map((recipe) => {
+      {mostRecentRecipes.slice(0, 4).map((recipe, index) => {
         return (
           <Link
+            key={index}
             to={`/docs/recipes/${recipe.doc_name.split(".")[0]}`}
             className={styles.recipeWrapper}
           >

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -10,6 +10,7 @@ import SVGImage from "../components/SVGImage";
 import { usePluginData } from "@docusaurus/useGlobalData";
 import * as Arrow from "@site/static/img/arrow.svg";
 import type { Snippet } from "../types";
+import LatestRelease from "../components/LatestVersion";
 
 const heroImage = require("@site/static/img/hero-graphic.svg");
 const faceWinking = require("@site/static/img/face-winking.png");
@@ -24,9 +25,6 @@ const NewSection = () => {
     (a, b) =>
       new Date(b.publish_date).getTime() - new Date(a.publish_date).getTime()
   )[0];
-
-  const igniteReleaseVersion = "v9.6.1";
-  const igniteReleaseDate = moment("2024-02-21").diff(moment(), "days") * -1;
 
   return (
     <div className={styles.newSection}>
@@ -54,27 +52,7 @@ const NewSection = () => {
         </div>
       )}
       <div className={styles.notificationSection}>
-        <p className={styles.notificationTagText}>Releases</p>
-        <h3 className={styles.notificationTitle}>Ignite Exp[ress]o ☕️</h3>
-        <p className={styles.notificationDate}>
-          {igniteReleaseDate > 0 ? (
-            <>
-              <b>{igniteReleaseVersion}</b> released{" "}
-              <b>{igniteReleaseDate} days ago</b>
-            </>
-          ) : (
-            <>
-              <b>{igniteReleaseVersion}</b> released today!
-            </>
-          )}
-        </p>
-        <Link
-          className={styles.notificationLink}
-          href={`https://github.com/infinitered/ignite/releases/tag/${igniteReleaseVersion}`}
-        >
-          <b className={styles.notificationLinkText}>View on Github</b>
-          <Arrow.default />
-        </Link>
+        <LatestRelease />
       </div>
     </div>
   );


### PR DESCRIPTION
This feature dynamically displays the latest Ignite release on the homepage. It fetches release info from GitHub API, showing the version and how many days ago it was released and falls back to a generic GitHub link to `/latest/ if unable to fetch. 

This approach seemed simpler than trying to implement a GH Action or using a version badge for the same info, but if we're not happy to include an API call on this site let me know :)
![Screenshot 2024-02-26 at 1 18 58 PM](https://github.com/infinitered/ignite-cookbook/assets/8878532/40859cdd-ca14-488d-8bb2-dc1f8e2ee9ae)

![Screenshot 2024-02-26 at 1 19 19 PM](https://github.com/infinitered/ignite-cookbook/assets/8878532/31c09e2e-ffb7-405d-a2be-2cc1ae409c85)

I also included 2 small fixes I noticed while working on this.
