### PR TITLE
Making headers links and fixing text alignment

### DIFF
--- a/src/components/LatestVersion/index.tsx
+++ b/src/components/LatestVersion/index.tsx
@@ -62,7 +62,14 @@ const LatestRelease = () => {
         </Link>
       ) : (
         <>
-          <h3 className={styles.notificationTitle}>Ignite</h3>
+          <h3 className={styles.notificationTitle}>
+            <Link
+              className={styles.notificationTitleLink}
+              href={`https://github.com/infinitered/ignite/releases/tag/${latestVersion}`}
+            >
+              Ignite
+            </Link>
+          </h3>
           <p className={styles.notificationDate}>
             <ReleaseRemark
               latestVersion={latestVersion}

--- a/src/pages/index.module.css
+++ b/src/pages/index.module.css
@@ -21,20 +21,16 @@
  }
 
  .notificationTag {
-  display: flex;
-  flex-direction: row;
-  align-items: flex-start;
-  padding: 4px 12px;
-  gap: 10px;
-  width: 103px;
-  height: 29px;
+  display: inline-block;
+  padding: 0px 12px;
   background: #E8C1B4;
  }
 
  .notificationTagText {
   color: #692810;
   font-size: 14px;
-  line-height: 21px;
+  line-height: 29px;
+  margin: 0px;
  }
 
 .notificationTitle {
@@ -44,6 +40,15 @@
   font-size: 20px;
   line-height: 24px;
 } 
+
+.notificationTitleLink {
+  color: inherit;
+}
+
+.notificationTitleLink:hover {
+  color: inherit;
+  text-decoration: underline;
+}
 
 .notificationDate {
   color: #564E4A;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -33,7 +33,14 @@ const NewSection = () => {
           <div className={styles.notificationTag}>
             <p className={styles.notificationTagText}>New Recipe</p>
           </div>
-          <h3 className={styles.notificationTitle}>{mostRecentRecipe.title}</h3>
+          <h3 className={styles.notificationTitle}>
+            <Link
+              className={styles.notificationTitleLink}
+              to={`/docs/recipes/${mostRecentRecipe.doc_name.split(".")[0]}`}
+            >
+              {mostRecentRecipe.title}
+            </Link>
+          </h3>
           <p className={styles.notificationDate}>
             {`Published on `}
             <b>


### PR DESCRIPTION
## Problem
While I was reviewing a recipe, I noticed the new recipe title and Ignite title were not clickable. They were they same color as the links on the page and I kept trying to click them each time I visited.

## Solution
Make the headers links for ease of navigation. Also align the text between the two columns so they have the same visual cadence. I'm using xScope for the guilds so you can seen the alignment.

| Before | After |
|--------|--------|
| <img width="1069" alt="image" src="https://github.com/infinitered/ignite-cookbook/assets/151139/56820f97-abbd-430e-b951-f210625946d4"> | <img width="1068" alt="image" src="https://github.com/infinitered/ignite-cookbook/assets/151139/57e8df0d-26b8-42e9-b7db-c1a0daa5e307"> |
| <video src="https://github.com/infinitered/ignite-cookbook/assets/151139/72d776fd-3da6-4783-8ff1-9f1c37413090" /> | <video src="https://github.com/infinitered/ignite-cookbook/assets/151139/50b01ba0-da56-4b65-a16f-48e40a230d97" /> | 
| ![Simulator Screenshot - iPhone 15 Pro - 2024-03-26 at 13 23 35](https://github.com/infinitered/ignite-cookbook/assets/151139/d13992da-e5db-4bf6-9a64-c2d661895f1d) | <video src="https://github.com/infinitered/ignite-cookbook/assets/151139/4f6a29c1-1f80-4330-8c32-337a6a70dcb9" /> |