### PR TITLE
style(select-field): dismiss button padding

### DIFF
--- a/docs/recipes/SelectFieldWithBottomSheet.mdx
+++ b/docs/recipes/SelectFieldWithBottomSheet.mdx
@@ -465,7 +465,7 @@ export const SelectField = forwardRef(function SelectField(
         }
       >
         <BottomSheetFlatList
-          style={{ marginBottom: bottom + (multiple ? 56 : 0) }}
+          style={{ marginBottom: bottom + (multiple ? spacing.xl * 2 : 0) }}
           data={options}
           keyExtractor={(o) => o.value}
           renderItem={({ item, index }) => (
@@ -485,6 +485,7 @@ export const SelectField = forwardRef(function SelectField(
 // success-line-start
 const $bottomSheetFooter: ViewStyle = {
   paddingHorizontal: spacing.lg,
+  paddingBottom: spacing.xs,
 };
 
 const $listItem: ViewStyle = {
@@ -633,7 +634,7 @@ export const SelectField = forwardRef(function SelectField(
         }
       >
         <BottomSheetFlatList
-          style={{ marginBottom: bottom + (multiple ? 56 : 0) }}
+          style={{ marginBottom: bottom + (multiple ? spacing.xl * 2 : 0) }}
           data={options}
           keyExtractor={(o) => o.value}
           renderItem={({ item, index }) => (
@@ -656,6 +657,7 @@ export const SelectField = forwardRef(function SelectField(
 
 const $bottomSheetFooter: ViewStyle = {
   paddingHorizontal: spacing.lg,
+  paddingBottom: spacing.xs,
 };
 
 const $listItem: ViewStyle = {


### PR DESCRIPTION
## Description
- Fixes an issue where the Dismiss button for `<SelectField ... multiple />` runs up against the screen edge on smaller devices

## Screenshots
### Before

<img src="https://github.com/infinitered/ignite-cookbook/assets/374022/ee6e04c1-2ba7-42ef-aebb-878da01f2b48" width="500" />


### After

<img src="https://github.com/infinitered/ignite-cookbook/assets/374022/6710c33d-bb96-494c-be77-3c890048c99b" width="500" />
