### PR TITLE
Minor edit: `const { signOut } = useAuth()` is missing a green highlight

### DIFF
--- a/docs/recipes/Authentication.md
+++ b/docs/recipes/Authentication.md
@@ -828,6 +828,7 @@ interface WelcomeScreenProps extends AppStackScreenProps<"Welcome"> {}
 export const WelcomeScreen: FC<WelcomeScreenProps> = observer(
   function WelcomeScreen() {
     const $bottomContainerInsets = useSafeAreaInsetsStyle(["bottom"])
+    // success-line
     const { signOut } = useAuth()
 
     return (


### PR DESCRIPTION
@morganick  Added `// success-line` above `const { signOut } = useAuth()`, as that is a change that should be highlighted green.  _(I haven't tested the render locally.)_

For reference this is the original :

![image](https://github.com/user-attachments/assets/eff21477-c2d4-4e9a-a96c-94cb1c86a112)

