### PR TITLE
Removed workaround

### DIFF
--- a/docs/recipes/Authentication.md
+++ b/docs/recipes/Authentication.md
@@ -351,9 +351,6 @@ const storage = new MMKV({
   id: "session",
 })
 
-// TODO: Remove this workaround for encryption: https://github.com/mrousavy/react-native-mmkv/issues/665
-storage.set("workaround", true)
-
 /**
  * A simple wrapper around MMKV that provides a base API
  * that matches AsyncStorage for use with Supabase.


### PR DESCRIPTION
```
// TODO: Remove this workaround for encryption: https://github.com/mrousavy/react-native-mmkv/issues/665
storage.set("workaround", true)
```

This line wasn't needed in my case, and the issue has been closed:

![brave_P0XJq4Bq2f](https://github.com/user-attachments/assets/c2efe864-9bb1-4a87-916d-01d25c20769c)

Can we remove it?

# Open Source License Notice for Contributors

If you are contributing a recipe to this repository, you agree to license your contribution under the terms of the [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/) license.

If you have any questions, please reference the [CONTRIBUTING.md](../CONTRIBUTING.md) or [LICENSE.md](../LICENSE.md) file for more information.

Thank you for your contribution!
